### PR TITLE
HAWKULAR-1275 Update new Hawkular Services

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/collector/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/collector/middleware_manager.rb
@@ -13,43 +13,75 @@ module ManageIQ::Providers
     end
 
     def oss
-      resources_for('Platform_Operating System')
+      oss = []
+      Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+        oss.concat(resources_for("Platform_Operating System #{version}"))
+      end
+      oss
     end
 
     def agents
-      resources_for('Hawkular WildFly Agent')
+      agents = []
+      Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+        agents.concat(resources_for("Hawkular Java Agent #{version}"))
+      end
+      agents
     end
 
     def eaps
-      resources_for('WildFly Server')
+      eaps = []
+      Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+        eaps.concat(resources_for("WildFly Server #{version}"))
+      end
+      eaps
     end
 
     def domain_servers
-      resources_for('Domain WildFly Server')
+      domains = []
+      Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+        domains.concat(resources_for("Domain WildFly Server #{version}"))
+      end
+      domains
     end
 
     def deployments
-      resources_for('Deployment')
+      deployments = []
+      Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+        deployments.concat(resources_for("Deployment #{version}"))
+      end
+      deployments
     end
 
     def subdeployments
-      resources_for('SubDeployment')
+      subdeployments = []
+      Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+        subdeployments.concat(resources_for("SubDeployment #{version}"))
+      end
+      subdeployments
     end
 
     def host_controllers
-      resources_for('Host Controller')
+      host_controllers = []
+      Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+        host_controllers.concat(resources_for("Host Controller #{version}"))
+      end
+      host_controllers
     end
 
     def domains
-      resources_for('Domain Host').select(&:domain_controller?)
+      domains = []
+      Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+        domains.concat(resources_for("Domain Host #{version}"))
+      end
+      domains
     end
 
     def child_resources(resource_id, recursive = false)
       manager.child_resources(resource_id, recursive)
     end
 
-    def raw_availability_data(*args)
-      connection.metrics.avail.raw_data(*args)
+    def raw_availability_data(metrics, time)
+      connection.prometheus.query(:metrics => metrics, :time => time)
     end
 
     private

--- a/app/models/manageiq/providers/hawkular/inventory/parser/availability_mixin.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/availability_mixin.rb
@@ -2,32 +2,26 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
   module AvailabilityMixin
     protected
 
-    def fetch_availabilities_for(resources, collection, metric_type_id)
-      metric_id_to_resources = resources.reject { |r| r.metrics_by_type(metric_type_id).empty? }.group_by do |resource|
-        resource.metrics_by_type(metric_type_id).first.hawkular_id
-      end
-      unless metric_id_to_resources.empty?
-        found_availabilities = []
-        collector.raw_availability_data(metric_id_to_resources.keys, :limit => 1, :order => 'DESC').each do |availability|
-          next unless metric_id_to_resources.key?(availability['id'])
-          found_availabilities << availability['id']
-          metric_id_to_resources.fetch(availability['id']).each do |hawkular_resource|
-            resource = collection.find_by(:ems_ref => hawkular_resource.id)
-            yield(resource, availability)
-          end
+    def fetch_availabilities_for(inventory_entities, entities, metric_name)
+      inventory_entities.each do |inventory_entity|
+        entity = entities.find_by(:ems_ref => inventory_entity.id)
+        availability = nil
+        availability_metric = filter_metric(inventory_entity, metric_name)
+        if availability_metric
+          availability = collector.raw_availability_data([availability_metric.to_h], Time.now.to_i)
         end
-        # Provide means to notify if there is a resource without the avail metric
-        ems_ref_of_unknown_avail = metric_id_to_resources.keys.to_set.subtract(found_availabilities).to_a
-        ems_ref_of_unknown_avail.each do |availability_id|
-          metric_id_to_resources.fetch(availability_id).each do |hawkular_resource|
-            yield(collection.find_by(:ems_ref => hawkular_resource.id), nil)
-          end
-        end
+        yield(entity, availability)
       end
     end
 
-    def process_availability(availability, translation = {})
-      translation.fetch(availability.try(:[], 'value').try(:downcase), 'Unknown')
+    def filter_metric(inventory_item, metric_name)
+      selected_metric = nil
+      inventory_item.metrics.each do |metric|
+        next unless metric.name.eql?(metric_name)
+        selected_metric = metric
+        break
+      end
+      selected_metric
     end
   end
 end

--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_domains.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_domains.rb
@@ -35,12 +35,16 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
       collection = persister.middleware_domains
       fetch_availabilities_for(collector.domains, collection, collection.model_class::AVAIL_TYPE_ID) do |domain, availability|
         domain.properties['Availability'] =
-          process_domain_availability(availability.try(:[], 'data').try(:first))
+          process_domain_availability(availability)
       end
     end
 
     def process_domain_availability(availability = nil)
-      process_availability(availability, 'up' => 'Running', 'down' => 'Stopped')
+      if availability.first['value'] && availability.first['value'][1] == '1'
+        'Running'
+      else
+        'STOPPED'
+      end
     end
 
     def parse_middleware_domain(domain, inventory_object)

--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_servers.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_servers.rb
@@ -50,7 +50,7 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
                                collection.model_class::AVAIL_TYPE_ID) do |server, availability|
         props = server.properties
         props['Availability'], props['Calculated Server State'] =
-          process_server_availability(props['Server State'], availability.try(:[], 'data').try(:first))
+          process_server_availability(props['Server State'], availability)
       end
     end
 
@@ -185,8 +185,12 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
     end
 
     def process_server_availability(server_state, availability = nil)
-      avail = availability.try(:[], 'value') || 'unknown'
-      [avail, avail == 'up' ? server_state : avail]
+      avail = if availability.first['value'] && availability.first['value'][1] == '1'
+                'Running'
+              else
+                'STOPPED'
+              end
+      [avail, avail == 'Running' ? server_state : avail]
     end
 
     def machine_id_by_feed(feed)

--- a/app/models/manageiq/providers/hawkular/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager.rb
@@ -23,6 +23,8 @@ module ManageIQ::Providers
     DEFAULT_PORT = 80
     default_value_for :port, DEFAULT_PORT
 
+    SUPPORTED_VERSIONS = %w(WF10 EAP6).freeze
+
     has_many :middleware_domains, :foreign_key => :ems_id, :dependent => :destroy
     has_many :middleware_servers, :foreign_key => :ems_id, :dependent => :destroy
     has_many :middleware_deployments, :foreign_key => :ems_id, :dependent => :destroy
@@ -152,8 +154,8 @@ module ManageIQ::Providers
       end
     end
 
-    def metrics_client
-      with_provider_connection(&:metrics)
+    def prometheus_client
+      with_provider_connection(&:prometheus)
     end
 
     def inventory_client

--- a/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/event_catcher/stream.rb
@@ -2,7 +2,6 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream
   def initialize(ems)
     @ems               = ems
     @alerts_client     = ems.alerts_client
-    @metrics_client    = ems.metrics_client
     @inventory_client  = ems.inventory_client
     @collecting_events = false
   end
@@ -134,9 +133,8 @@ class ManageIQ::Providers::Hawkular::MiddlewareManager::EventCatcher::Stream
 
     # Get availabilities
     avails = {}
-    parser.send(:fetch_availabilities_for, inventory_entities, entities, entities.first.class::AVAIL_TYPE_ID) do |item, avail|
-      avail_data = avail.try(:[], 'data').try(:first)
-      avails[item.id] = yield(item, avail_data)
+    parser.send(:fetch_availabilities_for, inventory_entities, entities, entities.first.class::AVAIL_TYPE_ID) do |item, availability|
+      avails[item.id] = yield(item, availability)
 
       # Filter out if availability is unchanged. This way, no refresh is triggered if unnecessary.
       avails.delete(item.id) unless avails[item.id]

--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
@@ -2,13 +2,14 @@ module ManageIQ::Providers
   class Hawkular::MiddlewareManager::LiveMetricsCapture
     class MetricValidationError < RuntimeError; end
 
+    ONE_HOUR = 60 * 60
+    ONE_DAY = 60 * 60 * 24
+    ONE_WEEK = ONE_DAY * 7
+
     def initialize(target)
       @target = target
       @ems = @target.ext_management_system
-      @metrics_client = @ems.metrics_client
-      @gauges = @metrics_client.gauges
-      @counters = @metrics_client.counters
-      @avail = @metrics_client.avail
+      @prometheus_client = @ems.prometheus_client
       @included_children = @target.included_children
       @supported_metrics = @target.supported_metrics
     end
@@ -16,112 +17,82 @@ module ManageIQ::Providers
     def fetch_metrics_available
       resource = @included_children ? @ems.resource_tree(@target.ems_ref) : @ems.resource(@target.ems_ref)
       resource.metrics(!!@included_children)
-              .select { |m| @supported_metrics.key?(m.hawkular_type_id) }.collect do |metric|
-        parse_metric(metric)
-      end
-    end
-
-    def parse_metric(metric)
-      {:id => metric.hawkular_id, :name => @supported_metrics[metric.hawkular_type_id], :type => metric.hawkular_type, :unit => metric.unit}
-    end
-
-    def parse_metrics_ids(metrics)
-      gauge_ids = []
-      counter_ids = []
-      avail_ids = []
-      metrics_ids_map = {}
-      metrics.each do |metric|
-        metric_id = metric[:id]
-        case metric[:type]
-        when "GAUGE"        then gauge_ids.push(metric_id)
-        when "COUNTER"      then counter_ids.push(metric_id)
-        when "AVAILABILITY" then avail_ids.push(metric_id)
-        end
-        metrics_ids_map[metric_id] = metric[:name]
-      end
-      [gauge_ids, counter_ids, avail_ids, metrics_ids_map]
+              .select { |metric| @supported_metrics[@target.live_metrics_type].key?(metric.name) }
+              .collect do |metric|
+                metric_hash = metric.to_h
+                metric_hash['name'] = @supported_metrics[@target.live_metrics_type][metric.name]
+                metric_hash
+              end
+              .to_a
     end
 
     def collect_stats_metrics(metrics, start_time, end_time, interval)
-      return [{}, {}] if metrics.empty?
-      gauge_ids, counter_ids, avail_ids, metrics_ids_map = parse_metrics_ids(metrics)
-      starts = start_time.to_i.in_milliseconds
-      ends = (end_time + interval).to_i.in_milliseconds + 1
-      bucket_duration = "#{interval}s"
-      raw_stats = @metrics_client.query_stats(:gauge_ids       => gauge_ids,
-                                              :counter_ids     => counter_ids,
-                                              :avail_ids       => avail_ids,
-                                              :rates           => true,
-                                              :starts          => starts,
-                                              :ends            => ends,
-                                              :bucket_duration => bucket_duration)
-      [metrics_ids_map, raw_stats]
+      return [] if metrics.empty?
+      starts = start_time.to_i
+      ends = (end_time + interval).to_i + 1
+      step = "#{interval}s"
+      results = @prometheus_client.query_range(:metrics => metrics,
+                                               :starts  => starts,
+                                               :ends    => ends,
+                                               :step    => step)
+      $mw_log.debug("collect_stats_metrics metrics: #{metrics} results: #{results}")
+      results
     end
 
     def collect_live_metrics(metrics, start_time, end_time, interval)
-      metrics_ids_map, raw_stats = collect_stats_metrics(metrics, start_time, end_time, interval)
-      process_stats(metrics_ids_map, raw_stats)
+      raw_stats = collect_stats_metrics(metrics, start_time, end_time, interval)
+      process_stats(raw_stats)
     end
 
-    def process_stats(metrics_ids_map, raw_stats)
+    def collect_report_metrics(report_cols, start_time, end_time, interval)
+      filtered = @target.metrics_available.select { |metric| report_cols.nil? || report_cols.include?(metric['name']) }
+      collect_live_metrics(filtered, start_time, end_time, interval)
+    end
+
+    def process_stats(raw_stats)
       processed = Hash.new { |h, k| h[k] = {} }
-      %w(availability gauge counter_rate).each do |type|
-        next unless raw_stats.key?(type)
-        raw_data = raw_stats[type]
-        raw_data.each do |metric_id, buckets|
-          metric_name = metrics_ids_map[metric_id]
-          norm_data = sort_and_normalize(buckets)
-          norm_data.each do |bucket|
-            timestamp = Time.at(bucket['start'] / 1.in_milliseconds).utc.to_i
-            value = type == 'availability' ? bucket['uptimeRatio'] : bucket['avg']
-            processed.store_path(timestamp, metric_name, value)
-          end
+      raw_stats.each do |raw_data|
+        next unless raw_data['values']
+        raw_data['values'].each do |datapoint|
+          timestamp = datapoint.first
+          value = datapoint.last.to_f
+          processed.store_path(timestamp, raw_data['metric']['name'], value)
         end
       end
       processed
     end
 
-    def first_and_last_capture_for_metrics(metrics)
-      firsts, lasts = metrics.collect do |metric|
-        first_and_last_capture(metric)
-      end.transpose
-      [firsts, lasts]
-    end
-
-    def first_and_last_capture(metric)
-      validate_metric(metric)
-      case metric[:type]
-      when "GAUGE"        then min_max_timestamps(@gauges, metric[:id])
-      when "COUNTER"      then min_max_timestamps(@counters, metric[:id])
-      when "AVAILABILITY" then min_max_timestamps(@avail, metric[:id])
-      else raise MetricValidationError, "Validation error: unknown type #{metric_type}"
+    def first_and_last_capture(interval_name = "realtime")
+      now = Time.new.utc
+      one_week_before = now - ONE_WEEK
+      last = now
+      first = now
+      results = @prometheus_client.up_time(:feed_id => @target.feed,
+                                           :starts  => one_week_before.to_i,
+                                           :ends    => now.to_i,
+                                           :step    => '3600m')
+      if results.empty?
+        one_day_before = now - ONE_DAY
+        results = @prometheus_client.up_time(:feed_id => @target.feed,
+                                             :starts  => one_day_before.to_i,
+                                             :ends    => now.to_i,
+                                             :step    => '60m')
       end
-    end
-
-    def validate_metric(metric)
-      unless metric && %i(id name type unit).all? { |k| metric.key?(k) }
-        raise MetricValidationError, "Validation error: metric #{metric} must be defined"
+      unless results.empty?
+        datapoint = results.first
+        first = Time.at(datapoint.first.to_i)
       end
+      if interval_name == "hourly"
+        first = (now - first) > 1.hour ? first : nil
+      end
+      $mw_log.debug("first_and_last_capture [first, last] #{[first, last]}")
+      [first, last]
     end
+  end
 
-    def min_max_timestamps(client, metric_id)
-      metric_def = client.get(metric_id)
-      [metric_def.json['minTimestamp'], metric_def.json['maxTimestamp']]
-    end
-
-    def sort_and_normalize(data)
-      # Sorting and removing last entry because always incomplete
-      # as it's still in progress.
-      norm_data = (data.sort_by { |x| x['start'] }).slice(0..-2)
-      norm_data.reject { |x| x.values.include?('NaN') }
-    end
-
-    private
-
-    def extract_feed(ems_ref)
-      s_start = ems_ref.index("/f;") + 3
-      s_end = ems_ref.index("/", s_start) - 1
-      ems_ref[s_start..s_end]
+  module Hawkular::MiddlewareManager::LiveMetricsCaptureMixin
+    def metrics_capture
+      @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)
     end
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_datasource.rb
@@ -1,4 +1,5 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareDatasource < MiddlewareDatasource
+    include ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCaptureMixin
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_messaging.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_messaging.rb
@@ -1,4 +1,25 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareMessaging < MiddlewareMessaging
+    include ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCaptureMixin
+
+    def live_metrics_type
+      messaging_type
+    end
+
+    def chart_report_name
+      @chart_report_name ||= if messaging_type.start_with?('JMS Queue')
+                               "#{self.class.name.demodulize.underscore}_jms_queue"
+                             else
+                               "#{self.class.name.demodulize.underscore}_jms_topic"
+                             end
+    end
+
+    def chart_layout_path
+      @chart_layout_path ||= if messaging_type.start_with?('JMS Queue')
+                               "#{self.class.name.demodulize}_jms_queue"
+                             else
+                               "#{self.class.name.demodulize}_jms_topic"
+                             end
+    end
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_server.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareServer < MiddlewareServer
+    include ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCaptureMixin
+
     AVAIL_TYPE_ID = 'Server Availability'.freeze
 
     has_many :middleware_diagnostic_reports, :dependent => :destroy
@@ -16,18 +18,6 @@ module ManageIQ::Providers
       middleware_diagnostic_reports.create!(
         :requesting_user => requesting_user
       )
-    end
-
-    def live_metrics_name
-      'middleware_server'
-    end
-
-    def chart_report_name
-      'middleware_server'
-    end
-
-    def self.supported_models
-      @supported_models ||= ['middleware_server']
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,7 +70,7 @@
   :worker_base:
     :event_catcher:
       :event_catcher_hawkular:
-        :poll: 10.seconds
+        :poll: 1.minute
       :event_catcher_hawkular_datawarehouse:
         :alertable_tenants: ['_system', '_ops']
         :poll: 1.minute

--- a/lib/hawkular_monkey_patches.rb
+++ b/lib/hawkular_monkey_patches.rb
@@ -11,15 +11,27 @@ module MonkeyPatches
         end
 
         def children_domain_hosts(recursive = false)
-          children_by_type('Domain Host', recursive)
+          children_domain_hosts = []
+          ManageIQ::Providers::Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+            children_by_type("Domain Host #{version}", recursive)
+          end
+          children_domain_hosts
         end
 
         def children_server_groups(recursive = false)
-          children_by_type('Domain Server Group', recursive)
+          children_server_groups = []
+          ManageIQ::Providers::Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+            children_by_type("Domain Server Group #{version}", recursive)
+          end
+          children_server_groups
         end
 
         def children_domain_servers(recursive = false)
-          children_by_type('Domain WildFly Server', recursive)
+          children_domain_servers = []
+          ManageIQ::Providers::Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
+            children_by_type("Domain WildFly Server #{version}", recursive)
+          end
+          children_domain_servers
         end
       end
     end


### PR DESCRIPTION
- Changes on Livemetrics, Reports and Availabilities

Not yet finished, as specs are pending, but this is working locally against a live Hawkular Services based on hawkular-1275 tag.

This requires:
https://github.com/hawkular/hawkular-client-ruby/pull/250
and
https://github.com/israel-hdez/manageiq/pull/1

Note, that to use hawkular-client locally, manageiq can update the gem like:
```
gem "hawkular-client",             ">=5.0.0.pre1",   :require => false, :git => "https://github.com/lucasponce/hawkular-client-ruby.git", :branch => "hawkular-1275"
```
And then you can use bundler.d/vendor.d to point to your local copy.