### PR TITLE
HAWKULAR-1275 Fix LiveMetricsCapture when provider is offline

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/collector/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/collector/middleware_manager.rb
@@ -82,17 +82,18 @@ module ManageIQ::Providers
 
     def raw_availability_data(metrics, time)
       connection.prometheus.query(:metrics => metrics, :time => time)
+    rescue => err
+      $mw_log.error(err)
+      nil
     end
 
     private
 
     def resources_for(resource_type)
-      begin
-        connection.inventory.resources_for_type(resource_type)
-      rescue => err
-        $mw_log.error(err)
-        []
-      end
+      connection.inventory.resources_for_type(resource_type)
+    rescue => err
+      $mw_log.error(err)
+      []
     end
   end
 end

--- a/app/models/manageiq/providers/hawkular/inventory/collector/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/collector/middleware_manager.rb
@@ -87,8 +87,12 @@ module ManageIQ::Providers
     private
 
     def resources_for(resource_type)
-      connection.inventory.resources_for_type(resource_type)
+      begin
+        connection.inventory.resources_for_type(resource_type)
+      rescue => err
+        $mw_log.error(err)
+        []
+      end
     end
-
   end
 end

--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_domains.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_domains.rb
@@ -40,6 +40,7 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
     end
 
     def process_domain_availability(availability = nil)
+      return 'unknown' if availability.nil?
       if availability.first['value'] && availability.first['value'][1] == '1'
         'Running'
       else

--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_server_entities.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_server_entities.rb
@@ -91,6 +91,7 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
     end
 
     def process_deployment_availability(availability = nil)
+      return 'unknown' if availability.nil?
       if availability.first['value'] && availability.first['value'][1] == '1'
         'Enabled'
       else

--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_servers.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_servers.rb
@@ -185,6 +185,7 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
     end
 
     def process_server_availability(server_state, availability = nil)
+      return ['unknown', 'unknown'] if availability.nil?
       avail = if availability.first['value'] && availability.first['value'][1] == '1'
                 'Running'
               else

--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
@@ -75,7 +75,7 @@ module ManageIQ::Providers
         results = @ems.prometheus_client.up_time(:feed_id => @target.feed,
                                              :starts  => one_week_before.to_i,
                                              :ends    => now.to_i,
-                                             :step    => '3600m')
+                                             :step    => '1440m')
         if results.empty?
           one_day_before = now - ONE_DAY
           results = @ems.prometheus_client.up_time(:feed_id => @target.feed,
@@ -96,12 +96,6 @@ module ManageIQ::Providers
         $mw_log.error(err)
         [nil, nil]
       end
-    end
-  end
-
-  module Hawkular::MiddlewareManager::LiveMetricsCaptureMixin
-    def metrics_capture
-      @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)
     end
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
@@ -9,21 +9,25 @@ module ManageIQ::Providers
     def initialize(target)
       @target = target
       @ems = @target.ext_management_system
-      @prometheus_client = @ems.prometheus_client
       @included_children = @target.included_children
       @supported_metrics = @target.supported_metrics
     end
 
     def fetch_metrics_available
-      resource = @included_children ? @ems.resource_tree(@target.ems_ref) : @ems.resource(@target.ems_ref)
-      resource.metrics(!!@included_children)
-              .select { |metric| @supported_metrics[@target.live_metrics_type].key?(metric.name) }
-              .collect do |metric|
-                metric_hash = metric.to_h
-                metric_hash['name'] = @supported_metrics[@target.live_metrics_type][metric.name]
-                metric_hash
-              end
-              .to_a
+      begin
+        resource = @included_children ? @ems.resource_tree(@target.ems_ref) : @ems.resource(@target.ems_ref)
+        resource.metrics(!!@included_children)
+                .select { |metric| @supported_metrics[@target.live_metrics_type].key?(metric.name) }
+                .collect do |metric|
+                  metric_hash = metric.to_h
+                  metric_hash['name'] = @supported_metrics[@target.live_metrics_type][metric.name]
+                  metric_hash
+                end
+                .to_a
+      rescue => err
+        $mw_log.error(err)
+        []
+      end
     end
 
     def collect_stats_metrics(metrics, start_time, end_time, interval)
@@ -31,7 +35,7 @@ module ManageIQ::Providers
       starts = start_time.to_i
       ends = (end_time + interval).to_i + 1
       step = "#{interval}s"
-      results = @prometheus_client.query_range(:metrics => metrics,
+      results = @ems.prometheus_client.query_range(:metrics => metrics,
                                                :starts  => starts,
                                                :ends    => ends,
                                                :step    => step)
@@ -63,30 +67,35 @@ module ManageIQ::Providers
     end
 
     def first_and_last_capture(interval_name = "realtime")
-      now = Time.new.utc
-      one_week_before = now - ONE_WEEK
-      last = now
-      first = now
-      results = @prometheus_client.up_time(:feed_id => @target.feed,
-                                           :starts  => one_week_before.to_i,
-                                           :ends    => now.to_i,
-                                           :step    => '3600m')
-      if results.empty?
-        one_day_before = now - ONE_DAY
-        results = @prometheus_client.up_time(:feed_id => @target.feed,
-                                             :starts  => one_day_before.to_i,
+      begin
+        now = Time.new.utc
+        one_week_before = now - ONE_WEEK
+        last = now
+        first = now
+        results = @ems.prometheus_client.up_time(:feed_id => @target.feed,
+                                             :starts  => one_week_before.to_i,
                                              :ends    => now.to_i,
-                                             :step    => '60m')
+                                             :step    => '3600m')
+        if results.empty?
+          one_day_before = now - ONE_DAY
+          results = @ems.prometheus_client.up_time(:feed_id => @target.feed,
+                                               :starts  => one_day_before.to_i,
+                                               :ends    => now.to_i,
+                                               :step    => '60m')
+        end
+        unless results.empty?
+          datapoint = results.first
+          first = Time.at(datapoint.first.to_i)
+        end
+        if interval_name == "hourly"
+          first = (now - first) > 1.hour ? first : nil
+        end
+        $mw_log.debug("first_and_last_capture [first, last] #{[first, last]}")
+        [first, last]
+      rescue => err
+        $mw_log.error(err)
+        [nil, nil]
       end
-      unless results.empty?
-        datapoint = results.first
-        first = Time.at(datapoint.first.to_i)
-      end
-      if interval_name == "hourly"
-        first = (now - first) > 1.hour ? first : nil
-      end
-      $mw_log.debug("first_and_last_capture [first, last] #{[first, last]}")
-      [first, last]
     end
   end
 

--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture.rb
@@ -85,7 +85,7 @@ module ManageIQ::Providers
         end
         unless results.empty?
           datapoint = results.first
-          first = Time.at(datapoint.first.to_i)
+          first = Time.at(datapoint.first.to_i).utc
         end
         if interval_name == "hourly"
           first = (now - first) > 1.hour ? first : nil

--- a/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture_mixin.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/live_metrics_capture_mixin.rb
@@ -1,0 +1,7 @@
+module ManageIQ::Providers
+  module Hawkular::MiddlewareManager::LiveMetricsCaptureMixin
+    def metrics_capture
+      @metrics_capture ||= ManageIQ::Providers::Hawkular::MiddlewareManager::LiveMetricsCapture.new(self)
+    end
+  end
+end


### PR DESCRIPTION
I didn't rescue properly the exceptions in my previous changes, so when provider is offline, invoking LiveMetrics fail in the UI.
On this way, exception is logged and empty data are shown (what is expected).