### PR TITLE
Enable rubocop in CI for pull requests

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -2,3 +2,9 @@ GlobalVars:
   AllowedVariables:
     - $datawarehouse_log
     - $mw_log
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+    '%I': '()'
+    '%w': '()'
+    '%W': '()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,11 @@ env:
   - RUBY_GC_HEAP_GROWTH_FACTOR=1.25
 addons:
   postgresql: '9.4'
-install: bin/setup
+install:
+  - bin/setup
+  - git fetch origin hawkular-1328 && git branch hawkular-1328 FETCH_HEAD
+  - gem install pronto-rubocop
+script:
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then pronto run -c hawkular-1328; fi
+  - bundle exec rake
 after_script: bundle exec codeclimate-test-reporter


### PR DESCRIPTION
This is to have rubocop to analyze our changes just in case we forget it.
Travis end with failure if rubocop complains. It will analyze only changed files and changed lines.

It's just to have more clean changes when we finally merge in the official repository.