### PR TITLE
Spec and Impl Domain Fixes

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_domains.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_domains.rb
@@ -40,7 +40,7 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
     end
 
     def process_domain_availability(availability = nil)
-      return 'unknown' if availability.nil?
+      return 'Unknown' if availability.nil? || availability.first.nil?
       if availability.first['value'] && availability.first['value'][1] == '1'
         'Running'
       else

--- a/app/models/manageiq/providers/hawkular/inventory/parser/middleware_server_entities.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/parser/middleware_server_entities.rb
@@ -91,13 +91,12 @@ module ManageIQ::Providers::Hawkular::Inventory::Parser
     end
 
     def process_deployment_availability(availability = nil)
+      return 'Unknown' if availability.nil? || availability.first.nil?
       if availability.first['value'] && availability.first['value'][1] == '1'
         'Enabled'
       else
         'Disabled'
       end
-    rescue
-      'Unknown'
     end
   end
 end

--- a/app/models/manageiq/providers/hawkular/middleware_manager/middleware_domain.rb
+++ b/app/models/manageiq/providers/hawkular/middleware_manager/middleware_domain.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class Hawkular::MiddlewareManager::MiddlewareDomain < MiddlewareDomain
-    AVAIL_TYPE_ID = 'Domain Availability'.freeze
+    AVAIL_TYPE_ID = 'Domain Host Availability'.freeze
 
     def properties
       self.properties = super || {}

--- a/lib/hawkular_monkey_patches.rb
+++ b/lib/hawkular_monkey_patches.rb
@@ -13,7 +13,8 @@ module MonkeyPatches
         def children_domain_hosts(recursive = false)
           children_domain_hosts = []
           ManageIQ::Providers::Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
-            children_by_type("Domain Host #{version}", recursive)
+            children_domain_hosts += children_by_type("Domain Host #{version}", recursive)
+            break unless children_domain_hosts.empty?
           end
           children_domain_hosts
         end
@@ -21,7 +22,8 @@ module MonkeyPatches
         def children_server_groups(recursive = false)
           children_server_groups = []
           ManageIQ::Providers::Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
-            children_by_type("Domain Server Group #{version}", recursive)
+            children_server_groups += children_by_type("Domain Server Group #{version}", recursive)
+            break unless children_server_groups.empty?
           end
           children_server_groups
         end
@@ -29,7 +31,8 @@ module MonkeyPatches
         def children_domain_servers(recursive = false)
           children_domain_servers = []
           ManageIQ::Providers::Hawkular::MiddlewareManager::SUPPORTED_VERSIONS.each do |version|
-            children_by_type("Domain WildFly Server #{version}", recursive)
+            children_domain_servers += children_by_type("Domain WildFly Server #{version}", recursive)
+            break unless children_domain_servers.empty?
           end
           children_domain_servers
         end

--- a/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_server_entities_spec.rb
+++ b/spec/models/manageiq/providers/hawkular/inventory/parser/middleware_server_entities_spec.rb
@@ -86,7 +86,7 @@ describe ManageIQ::Providers::Hawkular::Inventory::Parser::MiddlewareServerEntit
 
   describe 'deployments parser' do
     let(:metric_data) do
-      { 'metric' => {'__name__' => 'wildfly_deployment_availability'}, 'value' => [123, 'arbitary value'] }
+      { 'metric' => {'__name__' => 'wildfly_deployment_availability'}, 'value' => [123, 'arbitrary value'] }
     end
     let(:eap_children_hash) do
       {


### PR DESCRIPTION
Also:
- remove global 'rescue' from middleware_server_entities

@israel-hdez @josejulio @lucasponce, Note that there are some actual fixes included with the spec updates.