### PR TITLE
Fix unnecessary rescue on resources_for

### DIFF
--- a/app/models/manageiq/providers/hawkular/inventory/collector/middleware_manager.rb
+++ b/app/models/manageiq/providers/hawkular/inventory/collector/middleware_manager.rb
@@ -91,9 +91,6 @@ module ManageIQ::Providers
 
     def resources_for(resource_type)
       connection.inventory.resources_for_type(resource_type)
-    rescue => err
-      $mw_log.error(err)
-      []
     end
   end
 end


### PR DESCRIPTION
In the middle of a refresh process, this rescue can hide the connection error and send an empty array invalitading the current inventory.
That's incorrect. Last inventory should prevail.
I introduced this one when I added the rescue in an availability method which is still valid, so I have tested locally and it seems now it is fixed.